### PR TITLE
Fix build

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,8 +1,10 @@
 const build = require('@glimmer/build');
+const globSync = require('glob').sync;
+const path = require('path');
+
+const glimmerEngine = path.join(path.dirname(require.resolve('glimmer-engine/package')), 'dist/amd/glimmer-common.amd.js');
+const glimmerDi = globSync(path.join(path.dirname(require.resolve('@glimmer/di/package')), 'dist/amd/es5/**/*.js'));
 
 module.exports = build({
-  testDependencies: [
-    'node_modules/glimmer-engine/dist/amd/glimmer-common.amd.js',
-    'node_modules/@glimmer/di/dist/amd/es5/**/*.js'
-  ]
+  testDependencies: [glimmerEngine].concat(glimmerDi)
 });

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "glimmer-util": "^0.5.3"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.1.9",
+    "@glimmer/build": "^0.1.10",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
     "glimmer-engine": "^0.18.1",
+    "glob": "^7.1.1",
     "testem": "^1.13.0"
   }
 }

--- a/src/resolver-configuration.ts
+++ b/src/resolver-configuration.ts
@@ -43,7 +43,7 @@ export interface ModuleCollectionDefinition {
 }
 
 export interface ResolverConfiguration {
-  app: PackageDefinition;
+  app?: PackageDefinition;
   addons?: Dict<PackageDefinition>;
   types: Dict<ModuleTypeDefinition>;
   collections: Dict<ModuleCollectionDefinition>;

--- a/test/test-helpers/module-configurations.ts
+++ b/test/test-helpers/module-configurations.ts
@@ -1,6 +1,6 @@
-import { ModuleConfiguration, ModuleTypeDefinition, ModuleCollectionDefinition } from '../../src/module-configuration';
+import { ResolverConfiguration, ModuleTypeDefinition, ModuleCollectionDefinition } from '../../src/resolver-configuration';
 
-export const componentsOnlyConfiguration: ModuleConfiguration = {
+export const componentsOnlyConfiguration: ResolverConfiguration = {
   types: {
     'component': { 
       definitiveCollection: 'components' 


### PR DESCRIPTION
A number of things going on here:

- Needed update to absolute paths for `testDependencies`
- Needed update to `@glimmer/build@0.1.10`
- Globs are no bueno in `concat`'s `headerFiles` option
- `module-configuration` was renamed to `resolver-configuration` but never updated in `test/test-helpers/module-configurations.ts`
- `ModuleConfiguration` was renamed to `ResolverConfiguration` but never updated
- `ResolverConfiguration` required the `app` property but it was not present on the implementation in `test/test-helpers/module-configurations.ts`; I made it optional

