### PR TITLE
Bump @glimmer/util, di, and build packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 dist: trusty
 
 node_js:
-  - "4"
   - "6"
   - "node"
 

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,10 +1,17 @@
+"use strict";
+
 const build = require('@glimmer/build');
-const globSync = require('glob').sync;
+const buildVendorPackage = require('@glimmer/build/lib/build-vendor-package');
+const funnel = require('broccoli-funnel');
 const path = require('path');
 
-const glimmerEngine = path.join(path.dirname(require.resolve('glimmer-engine/package')), 'dist/amd/glimmer-common.amd.js');
-const glimmerDi = globSync(path.join(path.dirname(require.resolve('@glimmer/di/package')), 'dist/amd/es5/**/*.js'));
+let buildOptions = {};
 
-module.exports = build({
-  testDependencies: [glimmerEngine].concat(glimmerDi)
-});
+if (process.env.BROCCOLI_ENV === 'tests') {
+  buildOptions.vendorTrees = [
+    buildVendorPackage('@glimmer/util'),
+    funnel(path.dirname(require.resolve('@glimmer/di/package')), { include: ['dist/amd/es5/**/*.js'] })
+  ];
+}
+
+module.exports = build(buildOptions);

--- a/package.json
+++ b/package.json
@@ -23,15 +23,13 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/di": "^0.1.5",
-    "glimmer-util": "^0.5.3"
+    "@glimmer/di": "^0.1.6",
+    "@glimmer/util": "^0.21.0"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.1.10",
+    "@glimmer/build": "^0.2.0",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
-    "glimmer-engine": "^0.18.1",
-    "glob": "^7.1.1",
     "testem": "^1.13.0"
   }
 }

--- a/src/module-registries/basic-registry.ts
+++ b/src/module-registries/basic-registry.ts
@@ -1,5 +1,5 @@
 import { ModuleRegistry } from '../module-registry';
-import { dict, Dict } from 'glimmer-util';
+import { dict, Dict } from '@glimmer/util';
 
 export default class BasicRegistry implements ModuleRegistry {
   private _entries: Dict<any>;

--- a/src/resolver-configuration.ts
+++ b/src/resolver-configuration.ts
@@ -1,4 +1,4 @@
-import { Dict } from 'glimmer-util';
+import { Dict } from '@glimmer/util';
 
 export interface PackageDefinition {
   /**


### PR DESCRIPTION
Changes to the build process for tests allow us to remove the 
redundant glimmer-engine dependency.

[Closes #2]