### PR TITLE
Export Resolver as default for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/di": "^0.1.6",
+    "@glimmer/di": "^0.1.8",
     "@glimmer/util": "^0.21.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Resolver } from './resolver';
+export { default } from './resolver';
 export { default as BasicModuleRegistry } from './module-registries/basic-registry';
 export { ModuleRegistry } from './module-registry';
 export {


### PR DESCRIPTION
Allows for cleaner and more consistent imports:

```
import Resolver from '@glimmer/resolver';
```