### PR TITLE
Requirejs registry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 export { default } from './resolver';
 export { default as BasicModuleRegistry } from './module-registries/basic-registry';
+export { default as RequireJSModuleRegistry } from './module-registries/requirejs-registry';
+
 export { ModuleRegistry } from './module-registry';
 export {
   PackageDefinition,

--- a/src/module-registries/requirejs-registry.ts
+++ b/src/module-registries/requirejs-registry.ts
@@ -1,0 +1,54 @@
+declare var requirejs;
+declare var require;
+declare var console;
+
+import { ModuleRegistry } from '../module-registry';
+
+import {
+  deserializeSpecifier
+} from '@glimmer/di';
+
+export default class RequireJSRegistry implements ModuleRegistry {
+  private _config: any;
+  private _modulePrefix: string;
+
+  constructor(config: any, modulePrefix: string) {
+    this._config = config;
+    this._modulePrefix = modulePrefix;
+  }
+
+  normalize(specifier: string): string {
+    let s = deserializeSpecifier(specifier);
+
+    let type = s.collection === 'main' ? s.type : s.collection;
+    let collection = this._config.collections[s.collection];
+    let group = collection && collection.group;
+
+    if (group) {
+      type = `${group}/${type}`;
+    }
+
+    let path = `${s.rootName}/${this._modulePrefix}/${type}`;
+
+    if (s.name !== 'main') {
+      path += `/${s.name}`;
+    }
+
+    if (s.collection !== 'main') {
+      path += `/${s.type}`;
+    }
+
+    console.log(`requirejs ${specifier} -> ${path}`);
+    return path;
+  }
+
+  has(specifier: string): boolean {
+    let path = this.normalize(specifier);
+    return path in requirejs.entries;
+  }
+
+  get(specifier: string): any {
+    let path = this.normalize(specifier);
+    return require(path).default;
+  }
+}

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -45,7 +45,7 @@ export default class Resolver implements IResolver {
         if (result = this._serializeAndVerify(s)) { return result; }
 
         // Look for a private collection in the referrer's namespace
-        let privateCollection = this._definitiveCollection(s.type);
+        let privateCollection = this._definitiveCollection(s.type, s.namespace);
         if (privateCollection) {
           s.namespace += '/-' + privateCollection;
           if (result = this._serializeAndVerify(s)) { return result; }
@@ -58,14 +58,14 @@ export default class Resolver implements IResolver {
         assert('Referrer must either be "absolute" or include a `type` to determine the associated type', r.type);
 
         // Look in the definitive collection for the associated type
-        s.collection = this._definitiveCollection(r.type);
+        s.collection = this._definitiveCollection(r.type, r.namespace);
         assert(`'${r.type}' does not have a definitive collection`, s.collection);
       }
     }
 
     // If the collection is unspecified, use the definitive collection for the `type`
     if (!s.collection) {
-      s.collection = this._definitiveCollection(s.type);
+      s.collection = this._definitiveCollection(s.type, s.namespace);
       assert(`'${s.type}' does not have a definitive collection`, s.collection);
     }
 
@@ -102,9 +102,15 @@ export default class Resolver implements IResolver {
     }
   }
 
-  private _definitiveCollection(type: string): string {
+  private _definitiveCollection(type: string, collection: string): string {
     let typeDef = this.config.types[type];
     assert(`'${type}' is not a recognized type`, typeDef);
+
+    if (typeDef.fallbackCollectionPrefixes &&
+      typeDef.fallbackCollectionPrefixes[collection]) {
+        return typeDef.fallbackCollectionPrefixes[collection];
+    }
+
     return typeDef.definitiveCollection;
   }
 

--- a/test/requirejs-registry-test.ts
+++ b/test/requirejs-registry-test.ts
@@ -1,0 +1,60 @@
+import RequireJSRegistry from '../src/module-registries/requirejs-registry';
+import { ResolverConfiguration } from '../src/resolver-configuration';
+
+const { module, test } = QUnit;
+
+module('RequireJS Registry', {
+  beforeEach() {
+   let config: ResolverConfiguration = {
+    app: {
+      name: 'example-app',
+      rootName: 'example-app'
+    },
+    types: {
+      component: { definitiveCollection: 'components' },
+      route: { definitiveCollection: 'routes' },
+      router: { definitiveCollection: 'main' },
+      template: {
+        definitiveCollection: 'routes',
+        fallbackCollectionPrefixes: {
+          'components': 'components'
+        }
+      }
+    },
+    collections: {
+      'main': {
+        types: ['router']
+      },
+      components: {
+        group: 'ui',
+        types: ['component', 'helper', 'template']
+      },
+      routes: {
+        group: 'ui',
+        privateCollections: ['components'],
+        types: ['route', 'controller', 'template']
+      }
+    }
+  };
+
+  this.config = config;
+  this.registry = new RequireJSRegistry(this.config, 'src');
+  }
+});
+
+test('Normalize', function(assert) {
+  assert.expect(5);
+
+  [
+    [ 'router:/my-app/main/main', 'my-app/src/router' ],
+    [ 'route:/my-app/routes/application', 'my-app/src/ui/routes/application/route' ],
+    [ 'template:/my-app/routes/application', 'my-app/src/ui/routes/application/template' ],
+    [ 'component:/my-app/components/my-input', 'my-app/src/ui/components/my-input/component' ],
+
+    // have to check why components appears twice in this one, but it works...
+    [ 'template:/my-app/components/components/my-input', 'my-app/src/ui/components/my-input/template' ]
+  ]
+  .forEach(([ lookupString, expected ]) => {
+    assert.equal(this.registry.normalize(lookupString), expected);
+  })
+});

--- a/test/resolution-order-test.ts
+++ b/test/resolution-order-test.ts
@@ -278,3 +278,42 @@ test('Identifies `component:my-input/stylized` as an export from an addon', func
   let resolver = new Resolver(config, registry);
   assert.strictEqual(resolver.identify('component:my-input/stylized'), 'component:/my-input/components/stylized');
 });
+
+test('Identifies `template` from definitive collection or fallback collection', function(assert) {
+  let config: ResolverConfiguration = {
+    app: {
+      name: 'example-app',
+      rootName: 'example-app-root-name'
+    },
+    types: {
+      template: {
+        definitiveCollection: 'routes',
+        fallbackCollectionPrefixes: {
+          'components': 'components'
+        }
+      },
+    },
+    collections: {
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ],
+        defaultType: 'component'
+      },
+      routes: {
+        group: 'ui',
+        types: ['route', 'template']
+    },
+    }
+  };
+  let registry = new BasicRegistry({
+    'template:/example-app-root-name/routes/application': 'a',
+    'template:/example-app-root-name/components/components/my-input': 'b'
+  });
+  let resolver = new Resolver(config, registry);
+
+  assert.strictEqual(resolver.identify('template:application'),
+                     'template:/example-app-root-name/routes/application');
+
+  assert.strictEqual(resolver.identify('template:components/my-input'),
+                     'template:/example-app-root-name/components/components/my-input');
+});


### PR DESCRIPTION
 Adds a RequireJS Module Registry which can be used by Ember.

I have a test Ember app working with this.
 * [Branch of dangerously-set-unified-resolver that uses this resolver](https://github.com/201-created/dangerously-set-unified-resolver/compare/master...201-created:glimmer-resolver)
 * [Fork of new-app-blueprint that uses dangerously-set-unified-resolver](https://github.com/rwjblue/--new-app-blueprint/compare/master...201-created:glimmer-resolver)

For some reason `dangerously-set-unified-resolver` does not build unless it is npm linked to a local copy of `glimmer-resolver`, and likewise, `new-app-blueprint` doesn't build unless npm linked to a local copy of `dangerously-set-unified-resolver`. I could use a hand debugging that. When I navigate to `dangerously-set-unified-resolver/node_modules/@glimmer/resolver`, there is no `dist` folder at all, implying that it isn't getting built when running `npm install`.