### PR TITLE
Eliminate @glimmer/util dependency

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -7,8 +7,7 @@ let buildOptions = {};
 
 if (process.env.BROCCOLI_ENV === 'tests') {
   buildOptions.vendorTrees = [
-    buildVendorPackage('@glimmer/util', { external: ['babel-helpers'] }),
-    buildVendorPackage('@glimmer/di', { external: ['@glimmer/util', 'babel-helpers'] })
+    buildVendorPackage('@glimmer/di', { external: ['babel-helpers'] })
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/di": "^0.1.8",
-    "@glimmer/util": "^0.21.0"
+    "@glimmer/di": "^0.1.9"
   },
   "devDependencies": {
     "@glimmer/build": "^0.2.1",

--- a/src/module-registries/basic-registry.ts
+++ b/src/module-registries/basic-registry.ts
@@ -1,10 +1,10 @@
 import { ModuleRegistry } from '../module-registry';
-import { dict, Dict } from '@glimmer/util';
+import { Dict } from '@glimmer/di';
 
 export default class BasicRegistry implements ModuleRegistry {
   private _entries: Dict<any>;
 
-  constructor(entries: Dict<any> = dict<any>()) {
+  constructor(entries: Dict<any> = {}) {
     this._entries = entries;
   }
 

--- a/src/resolver-configuration.ts
+++ b/src/resolver-configuration.ts
@@ -1,4 +1,4 @@
-import { Dict } from '@glimmer/util';
+import { Dict } from '@glimmer/di';
 
 export interface PackageDefinition {
   /**


### PR DESCRIPTION
No longer needed now that @glimmer/di exports `Dict`.