### PR TITLE
Bump @glimmer/di and @glimmer/build

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -1,13 +1,14 @@
 "use strict";
 
 const build = require('@glimmer/build');
-const buildVendorPackage = require('@glimmer/build/lib/build-vendor-package');
+const funnel = require('broccoli-funnel');
+const path = require('path');
 
 let buildOptions = {};
 
 if (process.env.BROCCOLI_ENV === 'tests') {
   buildOptions.vendorTrees = [
-    buildVendorPackage('@glimmer/di', { external: ['babel-helpers'] })
+    funnel(path.dirname(require.resolve('@glimmer/di/package')), { include: ['dist/amd/es5/**/*.js'] })
   ];
 }
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "test": "testem ci"
   },
   "dependencies": {
-    "@glimmer/di": "^0.1.9"
+    "@glimmer/di": "^0.1.11"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.3.0",
+    "@glimmer/build": "^0.5.0",
     "broccoli": "^1.1.0",
     "broccoli-cli": "^1.0.0",
     "testem": "^1.13.0"


### PR DESCRIPTION
It's now possible to simply funnel test dependencies instead of rebuilding them.