### PR TITLE
Add `unresolvable` property to `ModuleTypeDefinition`

### DIFF
--- a/src/resolver-configuration.ts
+++ b/src/resolver-configuration.ts
@@ -32,6 +32,7 @@ export interface PackageDefinition {
 
 export interface ModuleTypeDefinition {
   definitiveCollection?: string;
+  unresolvable?: boolean;
 }
 
 export interface ModuleCollectionDefinition {


### PR DESCRIPTION
Goes along with https://github.com/glimmerjs/resolution-map-builder/pull/26