### PR TITLE
local lookup changes

### DIFF
--- a/src/resolver-configuration.ts
+++ b/src/resolver-configuration.ts
@@ -32,6 +32,7 @@ export interface PackageDefinition {
 
 export interface ModuleTypeDefinition {
   definitiveCollection?: string;
+  privateCollection?: string;
   unresolvable?: boolean;
 }
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -45,7 +45,7 @@ export default class Resolver implements IResolver {
         if (result = this._serializeAndVerify(s)) { return result; }
 
         // Look for a private collection in the referrer's namespace
-        let privateCollection = this._definitiveCollection(s.type);
+        let privateCollection = this._privateCollection(s.type);
         if (privateCollection) {
           s.namespace += '/-' + privateCollection;
           if (result = this._serializeAndVerify(s)) { return result; }
@@ -106,6 +106,12 @@ export default class Resolver implements IResolver {
     let typeDef = this.config.types[type];
     assert(`'${type}' is not a recognized type`, typeDef);
     return typeDef.definitiveCollection;
+  }
+
+  private _privateCollection(type: string): string {
+    let typeDef = this.config.types[type];
+    assert(`'${type}' is not a recognized type`, typeDef);
+    return typeDef.privateCollection;
   }
 
   private _serializeAndVerify(specifier: Specifier): string {

--- a/test/resolution-order-test.ts
+++ b/test/resolution-order-test.ts
@@ -64,15 +64,15 @@ test('Identifies `template` from `component:/app/components/my-form`', function(
     'template:/app/components/my-form': 'a'
   });
   let resolver = new Resolver(config, registry);
-  assert.strictEqual(resolver.identify('template', 
-                                       'component:/app/components/my-form'), 
+  assert.strictEqual(resolver.identify('template',
+                                       'component:/app/components/my-form'),
                      'template:/app/components/my-form');
 });
 
 /**
- * Private module resolution - If a source module is specified, look in a private collection at the source module's 
+ * Private module resolution - If a source module is specified, look in a private collection at the source module's
  * namespace, if one exists that is definitive for the requested type.
- * 
+ *
  * https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md#module-resolutions
  */
 module('Resolution order - 2. Private');
@@ -86,13 +86,14 @@ test('Identifies `component:my-input` in a private collection from `template:/ap
       template: {
       },
       component: {
-        definitiveCollection: 'components'
+        definitiveCollection: 'components',
+        privateCollection: 'components'
       },
       route: {
         definitiveCollection: 'routes'
       }
     },
-    collections: {      
+    collections: {
       components: {
         group: 'ui',
         types: ['component', 'template'],
@@ -113,9 +114,9 @@ test('Identifies `component:my-input` in a private collection from `template:/ap
 });
 
 /**
- * Associated module resolution - If an associated type is specified, look in the definitive collection for that associated type. Only resolve 
+ * Associated module resolution - If an associated type is specified, look in the definitive collection for that associated type. Only resolve
  * if the collection can contain the requested type.
- * 
+ *
  * https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md#module-resolutions
  */
 module('Resolution order - 3. Associated')
@@ -135,7 +136,7 @@ test('Identifies `template:my-input` given the associated type `component`', fun
         definitiveCollection: 'routes'
       }
     },
-    collections: {      
+    collections: {
       components: {
         group: 'ui',
         types: ['component', 'template'],
@@ -157,7 +158,7 @@ test('Identifies `template:my-input` given the associated type `component`', fun
 
 /**
  * Top-level module resolution - In the definitive collection for the requested type, defined at its top-level..
- * 
+ *
  * https://github.com/dgeb/rfcs/blob/module-unification/text/0000-module-unification.md#module-resolutions
  */
 module('Resolution order - 4. Top-level');
@@ -177,7 +178,7 @@ test('Identifies `component:my-input` at the top-level', function(assert) {
         definitiveCollection: 'routes'
       }
     },
-    collections: {      
+    collections: {
       components: {
         group: 'ui',
         types: ['component', 'template'],
@@ -218,7 +219,7 @@ test('Identifies `component:my-input` as the main export from an addon', functio
         definitiveCollection: 'routes'
       }
     },
-    collections: {      
+    collections: {
       components: {
         group: 'ui',
         types: ['component', 'template'],
@@ -259,7 +260,7 @@ test('Identifies `component:my-input/stylized` as an export from an addon', func
         definitiveCollection: 'routes'
       }
     },
-    collections: {      
+    collections: {
       components: {
         group: 'ui',
         types: ['component', 'template'],


### PR DESCRIPTION
 - separate config for privateCollection. This will allow both templates and components to be looked up under `-components`

 - Make configurable whether or not the resolver should fallback to looking for a global match when passed a referrer which does not yield a local factory.

Related PRs:
 - https://github.com/emberjs/ember.js/pull/15368
 - https://github.com/ember-cli/ember-resolver/pull/196