### PR TITLE
local resolution should be permitted in private collection

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -7,23 +7,9 @@ import {
   serializeSpecifier
 } from '@glimmer/di';
 import { assert } from './utils/debug';
+import { detectLocalResolutionCollection } from './utils/specifiers';
 import { ModuleRegistry } from './module-registry';
 import { ResolverConfiguration } from './resolver-configuration';
-
-function detectLocalResolutionCollection(specifier: Specifier): string {
-  let { namespace, collection } = specifier;
-
-  // Look for the local-most private collection contained in the namespace
-  // (which will appear closest to the end of the string)
-  let startPos = namespace.lastIndexOf('/-');
-  if (startPos > -1) {
-    startPos += 2;
-    let endPos = namespace.indexOf('/', startPos);
-    collection = namespace.slice(startPos, endPos > -1 ? endPos : undefined);
-  }
-
-  return collection;
-}
 
 export default class Resolver implements IResolver {
   public config: ResolverConfiguration;

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -10,6 +10,23 @@ import { assert } from './utils/debug';
 import { ModuleRegistry } from './module-registry';
 import { ResolverConfiguration } from './resolver-configuration';
 
+function detectLocalResolutionCollection(namespace) {
+  let collection;
+
+  if (namespace) {
+    let segments = namespace.split('/');
+    let segment;
+    while (segment = segments.pop()) {
+      if (segment.indexOf('-') === 0) {
+        collection = segment.slice(1);
+        break;
+      }
+    }
+  }
+
+  return collection;
+}
+
 export default class Resolver implements IResolver {
   public config: ResolverConfiguration;
   public registry: ModuleRegistry;
@@ -48,7 +65,9 @@ export default class Resolver implements IResolver {
         }
 
         s.namespace = r.namespace ? r.namespace + '/' + r.name : r.name;
-        if (s.collection === definitiveCollection) {
+        if (
+          (detectLocalResolutionCollection(s.namespace) || s.collection) === definitiveCollection
+        ) {
           /*
            * For specifiers with a name, try local resolution. Based on
            * the referrer.

--- a/src/utils/specifiers.ts
+++ b/src/utils/specifiers.ts
@@ -1,0 +1,16 @@
+import { Specifier } from '@glimmer/di';
+
+export function detectLocalResolutionCollection(specifier: Specifier): string {
+  let { namespace, collection } = specifier;
+
+  // Look for the local-most private collection contained in the namespace
+  // (which will appear closest to the end of the string)
+  let startPos = namespace.lastIndexOf('/-');
+  if (startPos > -1) {
+    startPos += 2;
+    let endPos = namespace.indexOf('/', startPos);
+    collection = namespace.slice(startPos, endPos > -1 ? endPos : undefined);
+  }
+
+  return collection;
+}

--- a/test/resolution-order-test.ts
+++ b/test/resolution-order-test.ts
@@ -205,6 +205,39 @@ test('Identifies `template` in `components` private collection from `template:/a
                      'template:/app/routes/my-page/-components/my-form');
 });
 
+test('Identifies local lookup in a private collection', function(assert) {
+  let config: ResolverConfiguration = {
+    app: {
+      name: 'example-app'
+    },
+    types: {
+      template: { definitiveCollection: 'components' },
+      component: { definitiveCollection: 'components' }
+    },
+    collections: {
+      routes: {
+        group: 'ui',
+        types: [ 'template' ]
+      },
+      components: {
+        group: 'ui',
+        types: [ 'component', 'template' ],
+        defaultType: 'component'
+      }
+    }
+  };
+  let registry = new BasicRegistry({
+    /* Expect that this entry is not matched */
+    'template:/app/routes/my-page/-components/my-form/-components/my-input': 'a',
+    /* Expect that this entry is matched */
+    'template:/app/routes/my-page/-components/my-form/my-input': 'a'
+  });
+  let resolver = new Resolver(config, registry);
+  assert.strictEqual(resolver.identify('template:my-input',
+                                       'template:/app/routes/my-page/-components/my-form'),
+                     'template:/app/routes/my-page/-components/my-form/my-input');
+});
+
 /**
  * Associated module resolution - If an associated type is specified, look in the definitive collection for that associated type. Only resolve
  * if the collection can contain the requested type.

--- a/test/utils/specifiers-test.ts
+++ b/test/utils/specifiers-test.ts
@@ -1,0 +1,23 @@
+import {
+  deserializeSpecifier
+} from '@glimmer/di';
+import { detectLocalResolutionCollection } from '../../src/utils/specifiers';
+
+const { module, test } = QUnit;
+
+module('Specifier utils');
+
+test('detectLocalResolutionCollection - favors a private collection over the top-level collection', function(assert) {
+  let specifier = deserializeSpecifier('template:/app/routes/my-page/-components/my-form/my-input');
+  assert.equal(detectLocalResolutionCollection(specifier), 'components');
+});
+
+test('detectLocalResolutionCollection - favors the most-local private collection over any other collections', function(assert) {
+  let specifier = deserializeSpecifier('template:/app/routes/my-page/-components/my-form/-helpers/my-input');
+  assert.equal(detectLocalResolutionCollection(specifier), 'helpers');
+});
+
+test('detectLocalResolutionCollection - uses the top-level collection if no private collections are present', function(assert) {
+  let specifier = deserializeSpecifier('component:/app/components/my-form/my-input');
+  assert.equal(detectLocalResolutionCollection(specifier), 'components');
+});


### PR DESCRIPTION
A failing test for some MU behavior.

I think the specifier deserialization should emit both the "top" collection (which is already does) and the local resolution collection (which may differ via a private collection). It seems cheaper to discover it when deserializing than to walk the namespace segments where I've done it here.

There are probably a few ways to do this.

Required for TravisCI to boot with MU.