### PR TITLE
Propagate referrer rootName to lookup namespace

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -71,6 +71,9 @@ export default class Resolver implements IResolver {
 
         // Look in the definitive collection for the associated type
         s.collection = this._definitiveCollection(r.type);
+        if (!s.namespace) {
+          s.namespace = r.rootName;
+        }
         assert(`'${r.type}' does not have a definitive collection`, s.collection);
       }
     }
@@ -89,11 +92,13 @@ export default class Resolver implements IResolver {
       // Then look for an addon with a matching `rootName`
       let addonDef;
       if (s.namespace) {
+        // Seems bad that addonDef is basically ignored?
         addonDef = this.config.addons && this.config.addons[s.namespace];
         s.rootName = s.namespace;
         s.namespace = undefined;
 
       } else {
+        // Seems bad that addonDef is basically ignored?
         addonDef = this.config.addons && this.config.addons[s.name];
         s.rootName = s.name;
         s.name = 'main';

--- a/test/resolution-order-test.ts
+++ b/test/resolution-order-test.ts
@@ -404,3 +404,36 @@ test('Identifies `component:my-input/stylized` as an export from an addon', func
   let resolver = new Resolver(config, registry);
   assert.strictEqual(resolver.identify('component:my-input/stylized'), 'component:/my-input/components/stylized');
 });
+
+test('Identifies `service:i18n` with referrer `service:/other-namespace-addon/` as an export from an addon', function(assert) {
+  let config: ResolverConfiguration = {
+    app: {
+      name: 'example-app'
+    },
+    addons: {
+      'other-namespace-addon': {
+        name: 'other-namespace-name',
+        rootName: 'other-namespace-rootName'
+      }
+    },
+    types: {
+      service: {
+        definitiveCollection: 'services'
+      },
+    },
+    collections: {
+      services: {
+        types: ['service'],
+        defaultType: 'service'
+      }
+    }
+  };
+  let registry = new BasicRegistry({
+    'service:/other-namespace-addon/services/i18n': 'a'
+  });
+  let resolver = new Resolver(config, registry);
+  assert.strictEqual(
+    resolver.identify('service:i18n', 'service:/other-namespace-addon/'),
+    'service:/other-namespace-addon/services/i18n'
+  );
+});

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "quotemark": [
+      true,
+      "single"
+    ]
+  }
+}


### PR DESCRIPTION
Permits lookups like:

```
resolver.identify('service:i18n', 'service:/other-namespace-addon/');
```

which resolves to `'service:/other-namespace-addon/services/i18n'`